### PR TITLE
fix - GetSolutionFolderProjects fail to detect recursive solution folders

### DIFF
--- a/AdjustNamespace.VsixShared/Helper/SolutionHelper.cs
+++ b/AdjustNamespace.VsixShared/Helper/SolutionHelper.cs
@@ -90,7 +90,8 @@ namespace AdjustNamespace.Helper
                         continue;
                     }
 
-                    if (subProject.Kind == EnvDTE80.ProjectKinds.vsProjectKindSolutionFolder)
+                    if (subProject.Kind != EnvDTE80.ProjectKinds.vsProjectKindSolutionFolder
+                        && ((dynamic)subProject.Object).Kind == EnvDTE80.ProjectKinds.vsProjectKindSolutionFolder)
                     {
                         subProject.SubProject.GetSolutionFolderProjects(ref foundTrueProjects);
                     }


### PR DESCRIPTION
Sub solution folder's Kind is not EnvDTE80.ProjectKinds.vsProjectKindSolutionFolder, so GetSolutionFolderProjects  fail to detect files in it