### PR TITLE
Fix for a crash where a no "x:" prefix is found (ie. ResourceDictionary)

### DIFF
--- a/AdjustNamespace.VsixShared/Xaml/XamlDocument.cs
+++ b/AdjustNamespace.VsixShared/Xaml/XamlDocument.cs
@@ -1,4 +1,4 @@
-﻿using AdjustNamespace.Xaml.BodyProvider;
+using AdjustNamespace.Xaml.BodyProvider;
 using AdjustNamespace.Xaml.Positioned;
 using System;
 using System.Collections.Generic;
@@ -187,6 +187,12 @@ namespace AdjustNamespace.Xaml
             {
                 //for maui
                 matches = Regex.Matches(xaml, @"xmlns\s?:\s?([\w\d]+)\s?=\s?\""http:\/\/schemas\.microsoft\.com\/winfx\/2009\/xaml\""");
+            }
+
+            if (matches.Count == 0)
+            {
+                // there is no x definition (i.e. ResourceDictionary etc)
+                return new XamlX(0, 0, "NO_X_ALIAS");
             }
 
             var match = matches[0];


### PR DESCRIPTION
The XamlDocument.ReadStructure expects the XAML file to contain a definition for a namespace "http://schemas.microsoft.com/winfx/2006/xaml" which in turn is used to find Classes and Static and Type references. The namespace however may be missing in a XAML file (for example if the XAML is a ResourceDictionary containing only styles) which crashes the Extension and produces incomplete results.

This fix creates a placeholder for the XamlX instance in such cases. The Xaml file is then processed as normal, with no crashes (returning no Class definitions as expected)